### PR TITLE
Remove Gem dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0 (2024-10-10)
+
+Remove Gem dependencies. Allow the consumers to decide on the version of the
+dependencies to use.
+
 ## 1.0.0 (2024-10-09)
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ utility.
 
 ```console
 $ bundle add pvb-rubocop --group=development
+$ bundle add rubocop --group=development
+$ bundle add rubocop-factory_bot --group=development
+$ bundle add rubocop-performance --group=development
+$ bundle add rubocop-rspec --group=development
 ```
 
 ## Usage

--- a/pvb-rubocop.gemspec
+++ b/pvb-rubocop.gemspec
@@ -9,9 +9,4 @@ Gem::Specification.new do |spec|
   spec.files = ['rubocop.yml']
   spec.homepage = 'https://github.com/Pioneer-Valley-Books/pvb-rubocop'
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
-
-  spec.add_dependency 'rubocop'
-  spec.add_dependency 'rubocop-factory_bot'
-  spec.add_dependency 'rubocop-performance'
-  spec.add_dependency 'rubocop-rspec'
 end

--- a/pvb-rubocop.gemspec
+++ b/pvb-rubocop.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'pvb-rubocop'
-  spec.version = '1.0.0'
+  spec.version = '2.0.0'
   spec.licenses = ['MIT']
   spec.summary = 'Pioneer Valley Books Rubocop Configuration'
   spec.authors = ['Pioneer Valley Books']


### PR DESCRIPTION
Let the consuming projects determine the version of dependent packages to use.

Remove all dependencies from gemspec.