### PR TITLE
Enable Style/ClassMethodsDefinitions cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -78,6 +78,9 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Enabled: false
 
+Style/ClassMethodsDefinitions:
+  Enabled: true
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
The details of the cop are available at:
https://docs.rubocop.org/rubocop/cops_style.html#styleclassmethodsdefinitions

> Enforces using def self.method_name or class << self to define class
> methods.