### PR TITLE
 Enable RuboCop Style/RequireOrder to manage require statements

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -87,6 +87,9 @@ Style/Documentation:
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
 
+Style/RequireOrder:
+  Enabled: true
+
 Style/SymbolArray:
   EnforcedStyle: brackets
 


### PR DESCRIPTION
Rather than manually order require statements in Ruby code, let RuboCop automate it in CI.

Docs on the cop are available at:
https://docs.rubocop.org/rubocop/1.69/cops_style.html#stylerequireorder

> Sort require and require_relative in alphabetical order.