### PR TITLE
Switch RuboCop extensions from using "require" to "plugins"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0 (2025-03-04)
+
+Migrate rubocop-performance and rubocop-rspec to use RuboCop plugin feature.
+
 ## 2.1.0 (2025-01-14)
 
 Enable `Style/RequireOrder` cop.

--- a/pvb-rubocop.gemspec
+++ b/pvb-rubocop.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'pvb-rubocop'
-  spec.version = '2.1.0'
+  spec.version = '2.2.0'
   spec.licenses = ['MIT']
   spec.summary = 'Pioneer Valley Books Rubocop Configuration'
   spec.authors = ['Pioneer Valley Books']

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,7 +1,9 @@
-require:
-  - rubocop-factory_bot
+plugins:
   - rubocop-performance
   - rubocop-rspec
+
+require:
+  - rubocop-factory_bot
 
 AllCops:
   NewCops: enable


### PR DESCRIPTION
The "plugins" option is an improved API for RuboCop extensions. It is now the preferred way to use and configure RuboCop extensions. This change resolves the following error:

```
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in .../literacyfootprints/vendor/bundle/ruby/3.4.0/gems/pvb-rubocop-2.1.0/rubocop.yml.

rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in .../literacyfootprints/vendor/bundle/ruby/3.4.0/gems/pvb-rubocop-2.1.0/rubocop.yml.
```

For more information, see
https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

Some RuboCop extensions don't yet have a new release with "plugins" support, so they haven't been modified.