### PR TITLE
Move "rubocop-factory_bot" to the "plugins" section of rubocop.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0 (2025-03-27)
+
+Migrate rubocop-performance and rubocop-rspec to use RuboCop plugin feature.
+
 ## 2.2.0 (2025-03-04)
 
 Migrate rubocop-performance and rubocop-rspec to use RuboCop plugin feature.

--- a/pvb-rubocop.gemspec
+++ b/pvb-rubocop.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'pvb-rubocop'
-  spec.version = '2.2.0'
+  spec.version = '2.3.0'
   spec.licenses = ['MIT']
   spec.summary = 'Pioneer Valley Books Rubocop Configuration'
   spec.authors = ['Pioneer Valley Books']

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,9 +1,7 @@
 plugins:
+  - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rspec
-
-require:
-  - rubocop-factory_bot
 
 AllCops:
   NewCops: enable


### PR DESCRIPTION
The "plugins" option is an new API for RuboCop extensions. It is now the preferred way to use and configure RuboCop extensions. This change resolves the following error:

```
rubocop-factory_bot extension supports plugin, specify `plugins: rubocop-factory_bot` instead of `require: rubocop-factory_bot` in .../vendor/bundle/ruby/3.4.0/gems/pvb-rubocop-2.2.0/rubocop.yml.
```

For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.