### PR TITLE
For Style/HashSyntax, set EnforcedShorthandSyntax option to always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0 (2025-08-18)
+
+For the cop `Style/HashSyntax`, set the `EnforcedShorthandSyntax` option to `always`.
+
 ## 2.3.0 (2025-03-27)
 
 Migrate rubocop-performance and rubocop-rspec to use RuboCop plugin feature.

--- a/pvb-rubocop.gemspec
+++ b/pvb-rubocop.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'pvb-rubocop'
-  spec.version = '2.3.0'
+  spec.version = '2.4.0'
   spec.licenses = ['MIT']
   spec.summary = 'Pioneer Valley Books Rubocop Configuration'
   spec.authors = ['Pioneer Valley Books']

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -87,6 +87,9 @@ Style/Documentation:
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
 Style/RequireOrder:
   Enabled: true
 


### PR DESCRIPTION
Documentation available at:

https://docs.rubocop.org/rubocop/1.79/cops_style.html#stylehashsyntax

```
# bad
{foo: foo, bar: bar}

# good
{foo:, bar:}

# good - allowed to mix syntaxes
{foo:, bar: baz}
```