### PR TITLE
Split rubocop.yml into two files to support non-Rails projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.0 (2026-01-28)
+
+Split rubocop.yml into two files to support non-Rails projects:
+
+- default.yml (cops that apply to all projects)
+- rails.yml (cops that only apply to Rails projects)
+
 ## 2.4.0 (2025-08-18)
 
 For the cop `Style/HashSyntax`, set the `EnforcedShorthandSyntax` option to `always`.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ utility.
 ```console
 $ bundle add pvb-rubocop --group=development
 $ bundle add rubocop --group=development
-$ bundle add rubocop-factory_bot --group=development
 $ bundle add rubocop-performance --group=development
+```
+
+For Rails projects:
+
+```console
+$ bundle add rubocop-factory_bot --group=development
 $ bundle add rubocop-rspec --group=development
 ```
 
@@ -19,7 +24,14 @@ Add the following to the `rubocop.yml` file:
 
 ```yaml
 inherit_gem:
-  pvb-rubocop: rubocop.yml
+  pvb-rubocop: default.yml
+```
+
+For Rails projects:
+
+```yaml
+inherit_gem:
+  pvb-rubocop: rails.yml
 ```
 
 For more details see rubocop documentation on

--- a/default.yml
+++ b/default.yml
@@ -1,7 +1,5 @@
 plugins:
-  - rubocop-factory_bot
   - rubocop-performance
-  - rubocop-rspec
 
 AllCops:
   NewCops: enable
@@ -61,21 +59,6 @@ Metrics:
   Enabled: false
 
 Naming/VariableNumber:
-  Enabled: false
-
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/MultipleMemoizedHelpers:
-  Enabled: false
-
-RSpec/NamedSubject:
-  Enabled: false
-
-RSpec/NestedGroups:
   Enabled: false
 
 Style/ClassMethodsDefinitions:

--- a/pvb-rubocop.gemspec
+++ b/pvb-rubocop.gemspec
@@ -2,11 +2,11 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'pvb-rubocop'
-  spec.version = '2.4.0'
+  spec.version = '3.0.0'
   spec.licenses = ['MIT']
   spec.summary = 'Pioneer Valley Books Rubocop Configuration'
   spec.authors = ['Pioneer Valley Books']
-  spec.files = ['rubocop.yml']
+  spec.files = ['default.yml', 'rails.yml']
   spec.homepage = 'https://github.com/Pioneer-Valley-Books/pvb-rubocop'
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
 end

--- a/rails.yml
+++ b/rails.yml
@@ -1,0 +1,20 @@
+inherit_from: default.yml
+
+plugins:
+  - rubocop-factory_bot
+  - rubocop-rspec
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false


### PR DESCRIPTION
Originally, pvb-rubocop only supported Rails-based projects, so a single rubocop.yml configuration was sufficient.

But now, to support non-Rails Ruby projects, the single configuration is split into:

- default.yml (cops that apply to all projects)
- rails.yml (cops that only apply to Rails projects)