### PR TITLE
Add rspec.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.0 (2026-01-28)
+## 3.1.0 (2026-02-10)
 
 Make an intermediate file for rspec projects. There are now 3 different project
 types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 3.1.0 (2026-02-10)
 
-Make an intermediate file for rspec projects. There are now 3 different project
+Make an intermediate file for RSpec projects. There are now 3 different project
 types:
 
 - default.yml (cops that apply to all projects)
-- rspec.yml (cops that only apply to Rspec projects)
+- rspec.yml (cops that only apply to RSpec projects)
 - rails.yml (cops that only apply to Rails projects)
 
 ## 3.0.0 (2026-01-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.1.0 (2026-01-28)
+
+Make an intermediate file for rspec projects. There are now 3 different project
+types:
+
+- default.yml (cops that apply to all projects)
+- rspec.yml (cops that only apply to Rspec projects)
+- rails.yml (cops that only apply to Rails projects)
+
 ## 3.0.0 (2026-01-28)
 
 Split rubocop.yml into two files to support non-Rails projects:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $ bundle add rubocop --group=development
 $ bundle add rubocop-performance --group=development
 ```
 
-For Rspec projects:
+For RSpec projects:
 
 ```console
 $ bundle add rubocop-rspec --group=development
@@ -32,7 +32,7 @@ inherit_gem:
   pvb-rubocop: default.yml
 ```
 
-For Rspec projects:
+For RSpec projects:
 
 ```yaml
 inherit_gem:

--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ $ bundle add rubocop --group=development
 $ bundle add rubocop-performance --group=development
 ```
 
+For Rspec projects:
+
+```console
+$ bundle add rubocop-rspec --group=development
+```
+
 For Rails projects:
 
 ```console
 $ bundle add rubocop-factory_bot --group=development
-$ bundle add rubocop-rspec --group=development
 ```
 
 ## Usage
@@ -25,6 +30,13 @@ Add the following to the `rubocop.yml` file:
 ```yaml
 inherit_gem:
   pvb-rubocop: default.yml
+```
+
+For Rspec projects:
+
+```yaml
+inherit_gem:
+  pvb-rubocop: rspec.yml
 ```
 
 For Rails projects:

--- a/pvb-rubocop.gemspec
+++ b/pvb-rubocop.gemspec
@@ -2,11 +2,11 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'pvb-rubocop'
-  spec.version = '3.0.0'
+  spec.version = '3.1.0'
   spec.licenses = ['MIT']
   spec.summary = 'Pioneer Valley Books Rubocop Configuration'
   spec.authors = ['Pioneer Valley Books']
-  spec.files = ['default.yml', 'rails.yml']
+  spec.files = ['default.yml', 'rails.yml', 'rspec.yml']
   spec.homepage = 'https://github.com/Pioneer-Valley-Books/pvb-rubocop'
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
 end

--- a/rails.yml
+++ b/rails.yml
@@ -1,20 +1,4 @@
-inherit_from: default.yml
+inherit_from: rspec.yml
 
 plugins:
   - rubocop-factory_bot
-  - rubocop-rspec
-
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/MultipleMemoizedHelpers:
-  Enabled: false
-
-RSpec/NamedSubject:
-  Enabled: false
-
-RSpec/NestedGroups:
-  Enabled: false

--- a/rspec.yml
+++ b/rspec.yml
@@ -1,0 +1,19 @@
+inherit_from: default.yml
+
+plugins:
+  - rubocop-rspec
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false


### PR DESCRIPTION
Projects have been identified where the rails.yml file includes unnecessary plugins for testing, such as rubocop-factory_bot. To optimize the testing environment and reduce unnecessary dependencies, a new rspec.yml file has been created specifically for projects that utilize RSpec for testing. This allows for a more streamlined and efficient testing setup, ensuring that only the necessary gems are included in the testing environment.