### PR TITLE
Add cop configuration for Layout/BlockAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0 (2026-05-04)
+
+Set `Layout/BlockAlignment` to `EnforcedStyleAlignWith: start_of_block`.
+
 ## 3.1.0 (2026-02-10)
 
 Make an intermediate file for RSpec projects. There are now 3 different project

--- a/default.yml
+++ b/default.yml
@@ -7,6 +7,9 @@ AllCops:
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: start_of_block
+
 Layout/ExtraSpacing:
   AllowForAlignment: false
 

--- a/pvb-rubocop.gemspec
+++ b/pvb-rubocop.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'pvb-rubocop'
-  spec.version = '3.1.0'
+  spec.version = '3.2.0'
   spec.licenses = ['MIT']
   spec.summary = 'Pioneer Valley Books Rubocop Configuration'
   spec.authors = ['Pioneer Valley Books']


### PR DESCRIPTION
Previously, block would be indented at confusing alignment. For example:

```rb
foo
  .bar
  .each do
  baz
end
```

Now the block is aligned relative to the dangling call:

```rb
foo
  .bar
  .each do
    baz
  end
```

Docs:

https://docs.rubocop.org/rubocop/latest/cops_layout.html#layoutblockalignment